### PR TITLE
Fix duplicate sidebar on pages

### DIFF
--- a/app/company-audit/page.tsx
+++ b/app/company-audit/page.tsx
@@ -3,7 +3,6 @@
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { useToast } from '@/components/ui/use-toast';
-import { Sidebar } from '@/components/sidebar';
 import { ProgressSteps } from '@/components/progress-steps';
 import { HelpPanel } from '@/components/help-panel';
 import { CompanyAudit } from '@/components/company-audit';
@@ -45,9 +44,8 @@ export default function CompanyAuditPage() {
 
   return (
     <div className="flex min-h-screen bg-black">
-      <Sidebar className="fixed left-0 top-0 h-full w-64" />
-      
-      <main className="flex-1 pl-64">
+
+      <main className="flex-1">
         <div className="sticky top-0 z-40 border-b border-neutral-800 bg-black/95 backdrop-blur supports-[backdrop-filter]:bg-black/80">
           <ProgressSteps currentStep={3} />
         </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { ProjectForm } from '@/components/project-form'
-import { Sidebar } from '@/components/sidebar'
 import { ProgressSteps } from '@/components/progress-steps'
 import { HelpPanel } from '@/components/help-panel'
 import { Button } from '@/components/ui/button'
@@ -50,9 +49,8 @@ export default function Page() {
 
   return (
     <div className="flex min-h-screen bg-black">
-      <Sidebar className="fixed left-0 top-0 h-full w-64" />
-      
-      <main className="flex-1 pl-64">
+
+      <main className="flex-1">
         <div className="sticky top-0 z-40 border-b border-neutral-800 bg-black/95 backdrop-blur supports-[backdrop-filter]:bg-black/80">
           <ProgressSteps currentStep={1} />
         </div>

--- a/app/step-2/page.tsx
+++ b/app/step-2/page.tsx
@@ -7,7 +7,6 @@ import { ProgressSteps } from '@/components/progress-steps'
 import { TeamMemberSection } from '@/components/team-member-section'
 import { SoftwareSelection } from '@/components/software-selection'
 import { AIToolsSelection } from '@/components/ai-tools-selection'
-import { Sidebar } from '@/components/sidebar'
 import { HelpPanel } from '@/components/help-panel'
 import { ArrowRight } from 'lucide-react'
 import { TeamMember, TeamDetails } from '@/lib/types'
@@ -31,9 +30,8 @@ export default function Step2Page() {
 
   return (
     <div className="flex min-h-screen bg-black">
-      <Sidebar className="fixed left-0 top-0 h-full w-64" />
-      
-      <main className="flex-1 pl-64">
+
+      <main className="flex-1">
         <div className="sticky top-0 z-40 border-b border-neutral-800 bg-black/95 backdrop-blur supports-[backdrop-filter]:bg-black/80">
           <ProgressSteps currentStep={2} />
         </div>

--- a/app/step-3/page.tsx
+++ b/app/step-3/page.tsx
@@ -6,7 +6,6 @@ import { ProgressSteps } from '@/components/progress-steps'
 import { QuestionForm } from '@/components/question-form'
 import { LoadingSpinner } from '@/components/ui/loading-spinner'
 import { Alert, AlertDescription } from '@/components/ui/alert'
-import { Sidebar } from '@/components/sidebar'
 import { HelpPanel } from '@/components/help-panel'
 import { BusinessDetails, TeamDetails } from '@/lib/types'
 
@@ -116,9 +115,8 @@ export default function Step3Page() {
 
   return (
     <div className="flex min-h-screen bg-black">
-      <Sidebar className="fixed left-0 top-0 h-full w-64" />
-      
-      <main className="flex-1 pl-64">
+
+      <main className="flex-1">
         <div className="sticky top-0 z-40 border-b border-neutral-800 bg-black/95 backdrop-blur supports-[backdrop-filter]:bg-black/80">
           <ProgressSteps currentStep={3} />
         </div>

--- a/app/step-4/page.tsx
+++ b/app/step-4/page.tsx
@@ -8,7 +8,6 @@ import { LoadingSpinner } from '@/components/ui/loading-spinner'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { CollapsibleSection } from '@/components/ui/collapsible-section'
 import { ArrowRight } from 'lucide-react'
-import { Sidebar } from '@/components/sidebar'
 import { HelpPanel } from '@/components/help-panel'
 import { QuickWinCard } from '@/components/quick-win-card'
 import { LongTermCard } from '@/components/long-term-card'
@@ -283,9 +282,8 @@ export default function Step4Page() {
 
   return (
     <div className="flex min-h-screen bg-black">
-      <Sidebar className="fixed left-0 top-0 h-full w-64" />
-      
-      <main className="flex-1 pl-64">
+
+      <main className="flex-1">
         <div className="sticky top-0 z-40 border-b border-neutral-800 bg-black/95 backdrop-blur supports-[backdrop-filter]:bg-black/80">
           <ProgressSteps currentStep={4} />
         </div>

--- a/app/step-5/page.tsx
+++ b/app/step-5/page.tsx
@@ -6,16 +6,14 @@ import { ProgressSteps } from '@/components/progress-steps'
 import { DocumentGenerator } from '@/components/document-generator'
 import { DocumentType } from '@/lib/documents'
 import { Card } from '@/components/ui/card'
-import { Sidebar } from '@/components/sidebar'
 
 export default function Step5Page() {
   const [selectedDoc, setSelectedDoc] = React.useState<DocumentType>('executiveSummary')
 
   return (
     <div className="flex min-h-screen bg-black">
-      <Sidebar className="fixed left-0 top-0 h-full w-64" />
-      
-      <main className="flex-1 pl-64">
+
+      <main className="flex-1">
         <div className="sticky top-0 z-40 border-b border-neutral-800 bg-black/95 backdrop-blur supports-[backdrop-filter]:bg-black/80">
           <ProgressSteps currentStep={5} />
         </div>

--- a/app/team/page.tsx
+++ b/app/team/page.tsx
@@ -1,15 +1,13 @@
 'use client'
 
-import { Sidebar } from '@/components/sidebar'
 import { ProgressSteps } from '@/components/progress-steps'
 import { HelpPanel } from '@/components/help-panel'
 
 export default function TeamPage() {
   return (
     <div className="flex min-h-screen bg-black">
-      <Sidebar className="fixed left-0 top-0 h-full w-64" />
-      
-      <main className="flex-1 pl-64">
+
+      <main className="flex-1">
         <div className="sticky top-0 z-40 border-b border-neutral-800 bg-black/95 backdrop-blur supports-[backdrop-filter]:bg-black/80">
           <ProgressSteps currentStep={2} />
         </div>


### PR DESCRIPTION
## Summary
- remove Sidebar component from individual pages
- rely on AppLayout for single sidebar

## Testing
- `npm run lint` *(fails: `next` not found)*